### PR TITLE
Adding react native binding into native sentry library to check if the app crashed last session.

### DIFF
--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -286,6 +286,15 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void didCrashLastLaunch(Promise promise) {
+        try {
+            promise.resolve(Sentry.isCrashedLastRun());
+        } catch (Exception e) {
+            promise.reject(e);
+        }
+    }
+
     private static PackageInfo getPackageInfo(Context ctx) {
         try {
             return ctx.getPackageManager().getPackageInfo(ctx.getPackageName(), 0);

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -355,6 +355,16 @@ RCT_EXPORT_METHOD(closeNativeSdk:(RCTPromiseResolveBlock)resolve
   resolve(@YES);
 }
 
+RCT_EXPORT_METHOD(didCrashLastLaunch:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if ([SentrySDK crashedLastRun]) {
+        resolve(@YES);
+    } else {
+        resolve(@NO);
+    }
+}
+
 RCT_EXPORT_METHOD(disableNativeFramesTracking)
 {
     // Do nothing on iOS, this bridge method only has an effect on android.

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -31,6 +31,13 @@ export class ReactNativeClient extends BaseClient<
   }
 
   /**
+   * Returns whether or not the last run resulted in a crash.
+   */
+  public didCrashLastLaunch(): PromiseLike<boolean> {
+    return NATIVE.didCrashLastLaunch().then((result: boolean) => result) as PromiseLike<boolean>;
+}
+
+  /**
    * @inheritDoc
    */
   public close(): PromiseLike<boolean> {

--- a/src/js/definitions.ts
+++ b/src/js/definitions.ts
@@ -43,6 +43,7 @@ export interface SentryNativeBridgeModule {
   clearBreadcrumbs(): void;
   crash(): void;
   closeNativeSdk(): PromiseLike<void>;
+  didCrashLastLaunch(): PromiseLike<boolean>;
   disableNativeFramesTracking(): void;
   fetchNativeRelease(): Promise<{
     build: string;

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -67,6 +67,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   setRelease,
   nativeCrash,
+  didCrashLastLaunch,
   flush,
   close,
 } from "./sdk";

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -168,6 +168,23 @@ export function nativeCrash(): void {
 }
 
 /**
+ * Returns whether or not the last run resulted in a crash.
+ */
+export async function didCrashLastLaunch(): Promise<boolean> {
+  try {
+    const client = getCurrentHub().getClient<ReactNativeClient>();
+    if (client) {
+      const result = await client.didCrashLastLaunch();
+      return result;
+    }
+  } catch (_) {}
+
+  logger.error("Failed to check if app crashed last launch.");
+
+  return false;
+}
+
+/**
  * Flushes all pending events in the queue to disk.
  * Use this before applying any realtime updates such as code-push or expo updates.
  */

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -40,6 +40,7 @@ interface SentryNativeWrapper {
   isNativeTransportAvailable(): boolean;
 
   initNativeSdk(options: ReactNativeOptions): PromiseLike<boolean>;
+  didCrashLastLaunch(): PromiseLike<boolean>;
   closeNativeSdk(): PromiseLike<void>;
 
   sendEvent(event: Event): PromiseLike<Response>;
@@ -457,6 +458,21 @@ export const NATIVE: SentryNativeWrapper = {
       this.enableNative = false;
     });
   },
+
+  /**
+   * Returns whether or not the last run resulted in a crash.
+   */
+  async didCrashLastLaunch(): Promise<boolean> {
+      if (!this.enableNative) {
+          return false;
+      }
+      if (!this._isModuleLoaded(RNSentry)) {
+          return false;
+      }
+
+      const didCrashLastLaunch = await RNSentry.didCrashLastLaunch();
+      return didCrashLastLaunch;
+},
 
   disableNativeFramesTracking(): void {
     if (!this.enableNative) {


### PR DESCRIPTION

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
A nice to have improvement, this exposes `didCrashLastRun` to react-native so clients can handle special case logic if their app crashed (and submitted a crash report to sentry) on the last run.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was originally implemented in https://github.com/getsentry/sentry-react-native/pull/329, but was reverted later on, as it was only implemented on the platform side but not actually accessible from react-native.


## :green_heart: How did you test it?
Launching on iOS / android devices, triggering a crash, then relaunching. 


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x ] No breaking changes

